### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@ under the License.
       <artifactId>plexus-component-annotations</artifactId>
     </dependency>
 
+    <!-- logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.16</version>
+      <version>1.7.36</version>
     </dependency>
 
     <!-- test -->

--- a/src/main/java/org/apache/maven/doxia/book/DefaultBookDoxia.java
+++ b/src/main/java/org/apache/maven/doxia/book/DefaultBookDoxia.java
@@ -48,7 +48,8 @@ import java.util.Set;
 public class DefaultBookDoxia
     implements BookDoxia
 {
-    private static final Logger logger = LoggerFactory.getLogger( DefaultBookDoxia.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DefaultBookDoxia.class );
+
     @Requirement
     private BookIo bookIo;
 

--- a/src/main/java/org/apache/maven/doxia/book/DefaultBookDoxia.java
+++ b/src/main/java/org/apache/maven/doxia/book/DefaultBookDoxia.java
@@ -28,7 +28,8 @@ import org.apache.maven.doxia.book.services.validation.BookValidator;
 import org.apache.maven.doxia.book.services.validation.ValidationResult;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Collections;
@@ -45,9 +46,9 @@ import java.util.Set;
  */
 @Component( role = BookDoxia.class )
 public class DefaultBookDoxia
-    extends AbstractLogEnabled
     implements BookDoxia
 {
+    private static final Logger logger = LoggerFactory.getLogger( DefaultBookDoxia.class );
     @Requirement
     private BookIo bookIo;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/indexer/DefaultBookIndexer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/indexer/DefaultBookIndexer.java
@@ -48,7 +48,8 @@ import org.slf4j.LoggerFactory;
 public class DefaultBookIndexer
     implements BookIndexer
 {
-    private static final Logger logger = LoggerFactory.getLogger( DefaultBookIndexer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DefaultBookIndexer.class );
+
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/indexer/DefaultBookIndexer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/indexer/DefaultBookIndexer.java
@@ -35,7 +35,8 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.manager.ParserNotFoundException;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of BookIndexer.
@@ -45,9 +46,9 @@ import org.codehaus.plexus.logging.AbstractLogEnabled;
  */
 @Component( role = BookIndexer.class )
 public class DefaultBookIndexer
-    extends AbstractLogEnabled
     implements BookIndexer
 {
+    private static final Logger logger = LoggerFactory.getLogger( DefaultBookIndexer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/io/DefaultBookIo.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/io/DefaultBookIo.java
@@ -51,7 +51,8 @@ import java.util.List;
 public class DefaultBookIo
     implements BookIo
 {
-    private static final Logger logger = LoggerFactory.getLogger( DefaultBookIo.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DefaultBookIo.class );
+
     @Requirement
     private SiteModuleManager siteModuleManager;
 
@@ -128,9 +129,9 @@ public class DefaultBookIo
             }
         }
 
-        if ( logger.isDebugEnabled() )
+        if ( LOGGER.isDebugEnabled() )
         {
-            logger.debug( "Dumping document <-> id mapping:" );
+            LOGGER.debug( "Dumping document <-> id mapping:" );
 
             Map<String, BookContext.BookFile> map = new TreeMap<>( context.getFiles() );
 
@@ -138,7 +139,7 @@ public class DefaultBookIo
             {
                 BookContext.BookFile file = entry.getValue();
 
-                logger.debug( " " + entry.getKey() + "=" + file.getFile() + ", parser: " + file.getParserId() );
+                LOGGER.debug( " " + entry.getKey() + "=" + file.getFile() + ", parser: " + file.getParserId() );
             }
         }
     }

--- a/src/main/java/org/apache/maven/doxia/book/services/io/DefaultBookIo.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/io/DefaultBookIo.java
@@ -28,9 +28,10 @@ import org.apache.maven.doxia.module.site.manager.SiteModuleManager;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import java.io.IOException;
 import java.io.File;
@@ -48,9 +49,9 @@ import java.util.List;
  */
 @Component( role = BookIo.class )
 public class DefaultBookIo
-    extends AbstractLogEnabled
     implements BookIo
 {
+    private static final Logger logger = LoggerFactory.getLogger( DefaultBookIo.class );
     @Requirement
     private SiteModuleManager siteModuleManager;
 
@@ -127,9 +128,9 @@ public class DefaultBookIo
             }
         }
 
-        if ( getLogger().isDebugEnabled() )
+        if ( logger.isDebugEnabled() )
         {
-            getLogger().debug( "Dumping document <-> id mapping:" );
+            logger.debug( "Dumping document <-> id mapping:" );
 
             Map<String, BookContext.BookFile> map = new TreeMap<>( context.getFiles() );
 
@@ -137,7 +138,7 @@ public class DefaultBookIo
             {
                 BookContext.BookFile file = entry.getValue();
 
-                getLogger().debug( " " + entry.getKey() + "=" + file.getFile() + ", parser: " + file.getParserId() );
+                logger.debug( " " + entry.getKey() + "=" + file.getFile() + ", parser: " + file.getParserId() );
             }
         }
     }

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/AbstractITextBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/AbstractITextBookRenderer.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractITextBookRenderer
     implements BookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( AbstractITextBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( AbstractITextBookRenderer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/AbstractITextBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/AbstractITextBookRenderer.java
@@ -38,11 +38,12 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.manager.ParserNotFoundException;
 import org.apache.maven.doxia.sink.Sink;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.WriterFactory;
 import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for <code>iText</code> renderer.
@@ -52,9 +53,9 @@ import org.codehaus.plexus.util.xml.PrettyPrintXMLWriter;
  * @version $Id$
  */
 public abstract class AbstractITextBookRenderer
-    extends AbstractLogEnabled
     implements BookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( AbstractITextBookRenderer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/DocbookBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/DocbookBookRenderer.java
@@ -37,11 +37,12 @@ import org.apache.maven.doxia.parser.manager.ParserNotFoundException;
 import org.apache.maven.doxia.sink.Sink;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.WriterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of <code>BookRenderer</code> for docbook
@@ -51,9 +52,9 @@ import org.codehaus.plexus.util.WriterFactory;
  */
 @Component( role = BookRenderer.class, hint = "doc-book" )
 public class DocbookBookRenderer
-    extends AbstractLogEnabled
     implements BookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( DocbookBookRenderer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/DocbookBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/DocbookBookRenderer.java
@@ -54,7 +54,8 @@ import org.slf4j.LoggerFactory;
 public class DocbookBookRenderer
     implements BookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( DocbookBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DocbookBookRenderer.class );
+
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/PdfBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/PdfBookRenderer.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class PdfBookRenderer
     extends AbstractITextBookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( PdfBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PdfBookRenderer.class );
 
     /** {@inheritDoc} */
     public String getOutputExtension()

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/PdfBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/PdfBookRenderer.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 
 import org.apache.maven.doxia.module.itext.ITextUtil;
 import org.codehaus.plexus.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PDF book renderer with the <code>iText</code> framework.
@@ -37,6 +39,8 @@ import org.codehaus.plexus.component.annotations.Component;
 public class PdfBookRenderer
     extends AbstractITextBookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( PdfBookRenderer.class );
+
     /** {@inheritDoc} */
     public String getOutputExtension()
     {

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/RtfBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/RtfBookRenderer.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 
 import org.apache.maven.doxia.module.itext.ITextUtil;
 import org.codehaus.plexus.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * RTF book renderer with the <code>iText</code> framework.
@@ -37,6 +39,8 @@ import org.codehaus.plexus.component.annotations.Component;
 public class RtfBookRenderer
     extends AbstractITextBookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( RtfBookRenderer.class );
+
     /** {@inheritDoc} */
     public String getOutputExtension()
     {

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/RtfBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/RtfBookRenderer.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class RtfBookRenderer
     extends AbstractITextBookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( RtfBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RtfBookRenderer.class );
 
     /** {@inheritDoc} */
     public String getOutputExtension()

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/XHtmlBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/XHtmlBookRenderer.java
@@ -53,7 +53,8 @@ import java.io.Writer;
 public class XHtmlBookRenderer
     implements BookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( XHtmlBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( XHtmlBookRenderer.class );
+
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/XHtmlBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/XHtmlBookRenderer.java
@@ -31,9 +31,10 @@ import org.apache.maven.doxia.parser.manager.ParserNotFoundException;
 import org.apache.maven.doxia.parser.ParseException;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -50,9 +51,9 @@ import java.io.Writer;
  */
 @Component( role = BookRenderer.class, hint = "xhtml" )
 public class XHtmlBookRenderer
-    extends AbstractLogEnabled
     implements BookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( XHtmlBookRenderer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/XdocBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/XdocBookRenderer.java
@@ -44,10 +44,11 @@ import org.apache.maven.doxia.util.HtmlTools;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.i18n.I18N;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.WriterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of <code>BookRenderer</code> for Xdoc
@@ -58,9 +59,9 @@ import org.codehaus.plexus.util.WriterFactory;
  */
 @Component( role = BookRenderer.class, hint = "xdoc" )
 public class XdocBookRenderer
-    extends AbstractLogEnabled
     implements BookRenderer
 {
+    private static final Logger logger = LoggerFactory.getLogger( XdocBookRenderer.class );
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/renderer/XdocBookRenderer.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/renderer/XdocBookRenderer.java
@@ -61,7 +61,8 @@ import org.slf4j.LoggerFactory;
 public class XdocBookRenderer
     implements BookRenderer
 {
-    private static final Logger logger = LoggerFactory.getLogger( XdocBookRenderer.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( XdocBookRenderer.class );
+
     @Requirement
     private Doxia doxia;
 

--- a/src/main/java/org/apache/maven/doxia/book/services/validation/DefaultBookValidator.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/validation/DefaultBookValidator.java
@@ -37,7 +37,7 @@ import org.apache.maven.doxia.book.model.Chapter;
 public class DefaultBookValidator
     implements BookValidator
 {
-    private static final Logger logger = LoggerFactory.getLogger( DefaultBookValidator.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DefaultBookValidator.class );
 
     // ----------------------------------------------------------------------
     // BookValidator Implementation

--- a/src/main/java/org/apache/maven/doxia/book/services/validation/DefaultBookValidator.java
+++ b/src/main/java/org/apache/maven/doxia/book/services/validation/DefaultBookValidator.java
@@ -20,8 +20,10 @@ package org.apache.maven.doxia.book.services.validation;
  */
 
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.maven.doxia.book.model.BookModel;
 import org.apache.maven.doxia.book.model.Chapter;
 
@@ -33,9 +35,10 @@ import org.apache.maven.doxia.book.model.Chapter;
  */
 @Component( role = BookValidator.class )
 public class DefaultBookValidator
-    extends AbstractLogEnabled
     implements BookValidator
 {
+    private static final Logger logger = LoggerFactory.getLogger( DefaultBookValidator.class );
+
     // ----------------------------------------------------------------------
     // BookValidator Implementation
     // ----------------------------------------------------------------------


### PR DESCRIPTION
As seen on https://cwiki.apache.org/confluence/plugins/servlet/mobile?contentId=181305684#MavenEcosystemCleanup-DropPlexusContainerforJSR-330+SisuGuiceextension

- Leverages https://github.com/openrewrite/rewrite-apache/pull/41

I have another two lined up for apache/maven and apache/maven-archetype that I'll verify first.

@elharo if you wouldn't mind, could you look this over?

Use this link to re-run the recipe: https://app.moderne.io/builder/P4zH7djn6?organizationId=QXBhY2hlIE1hdmVu